### PR TITLE
use pat for scala steward prs

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -25,3 +25,5 @@ jobs:
           cache: sbt
       - name: Scala Steward
         uses: scala-steward-org/scala-steward-action@v2
+        with:
+          github-token: ${{ secrets.SCALA_STEWARD_GITHUB_TOKEN }}


### PR DESCRIPTION
Seems creating PRs using the default token does not trigger checks. This
change is to see if using a PAT changes things.

Reference:
- https://github.com/orgs/community/discussions/25602
